### PR TITLE
Feature/setup.py

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,7 @@
 Place solarized.py in site-packages/pygments/styles/ to use with Pygments.
 
+Or, use the setup.py:
+
+    ./setup.py install
+
 This style is based on the light version of [Solarized](https://github.com/altercation/solarized).

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+
+from setuptools import setup, find_packages
+
+setup(
+    name='solarized-pygment',
+    version='0.1',
+    description='Pygments version of the solarized theme.',
+    keywords='pygments style solarized',
+    #license='BSD',
+    author='John Louis Del Rosario',
+    author_email='john2x@gmail.com',
+
+    url='https://github.com/john2x/solarized-pygment',
+
+    py_modules=['solarized'],
+    install_requires=['pygments >= 1.4'],
+
+    entry_points='''[pygments.styles]
+                    solarized=solarized:SolarizedStyle''',
+
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        #'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+)

--- a/solarized.py
+++ b/solarized.py
@@ -20,6 +20,7 @@ CYAN = '#2aa198'
 GREEN = '#859900'
 
 class SolarizedStyle(Style):
+    """ Pygments version of the solarized theme. """
     background_color = BASE2
     styles = {
         Text                    : 'bg: %s %s' % (BASE2, BASE01),


### PR DESCRIPTION
The `setup.py` allows for easy installation as an entry point for pygments. This is the recommended (apparently) way to install styles for pygments. If you are interested, an alternative is to monkey patch pygments, cf. https://github.com/esc/best-practices-talk/blob/master/pygmentize.
